### PR TITLE
Float bool translators

### DIFF
--- a/apps/service_persist/lib/persist/dictionary/translator.ex
+++ b/apps/service_persist/lib/persist/dictionary/translator.ex
@@ -32,7 +32,7 @@ defmodule Persist.Dictionary do
 
   defimpl Translator, for: Dictionary.Type.Integer do
     def translate_type(%{name: name}) do
-      %Result{name: name, type: "integer"}
+      %Result{name: name, type: "bigint"}
     end
 
     def translate_value(_field, value), do: value

--- a/apps/service_persist/lib/persist/dictionary/translator.ex
+++ b/apps/service_persist/lib/persist/dictionary/translator.ex
@@ -38,6 +38,22 @@ defmodule Persist.Dictionary do
     def translate_value(_field, value), do: value
   end
 
+  defimpl Translator, for: Dictionary.Type.Float do
+    def translate_type(%{name: name}) do
+      %Result{name: name, type: "double"}
+    end
+
+    def translate_value(_field, value), do: value
+  end
+
+  defimpl Translator, for: Dictionary.Type.Boolean do
+    def translate_type(%{name: name}) do
+      %Result{name: name, type: "boolean"}
+    end
+
+    def translate_value(_field, value), do: value
+  end
+
   defimpl Translator, for: Dictionary.Type.Date do
     def translate_type(%{name: name}) do
       %Result{name: name, type: "date"}

--- a/apps/service_persist/test/persist/dictionary_test.exs
+++ b/apps/service_persist/test/persist/dictionary_test.exs
@@ -13,7 +13,7 @@ defmodule Persist.DictionaryTest do
     where([
       [:field, :expected],
       [Dictionary.Type.String.new!(name: "name"), %Result{name: "name", type: "varchar"}],
-      [Dictionary.Type.Integer.new!(name: "age"), %Result{name: "age", type: "integer"}],
+      [Dictionary.Type.Integer.new!(name: "age"), %Result{name: "age", type: "bigint"}],
       [
         Dictionary.Type.Date.new!(name: "date", format: "%Y"),
         %Result{name: "date", type: "date"}
@@ -34,7 +34,7 @@ defmodule Persist.DictionaryTest do
             Dictionary.Type.Integer.new!(name: "age")
           ]
         ),
-        %Result{name: "spouse", type: "row(name varchar,age integer)"}
+        %Result{name: "spouse", type: "row(name varchar,age bigint)"}
       ],
       [
         Dictionary.Type.List.new!(name: "colors", item_type: Dictionary.Type.String),
@@ -49,7 +49,7 @@ defmodule Persist.DictionaryTest do
             Dictionary.Type.Integer.new!(name: "age")
           ]
         ),
-        %Result{name: "friends", type: "array(row(name varchar,age integer))"}
+        %Result{name: "friends", type: "array(row(name varchar,age bigint))"}
       ]
     ])
   end

--- a/apps/service_persist/test/persist/dictionary_test.exs
+++ b/apps/service_persist/test/persist/dictionary_test.exs
@@ -15,6 +15,11 @@ defmodule Persist.DictionaryTest do
       [Dictionary.Type.String.new!(name: "name"), %Result{name: "name", type: "varchar"}],
       [Dictionary.Type.Integer.new!(name: "age"), %Result{name: "age", type: "bigint"}],
       [
+        Dictionary.Type.Float.new!(name: "percentage"),
+        %Result{name: "percentage", type: "double"}
+      ],
+      [Dictionary.Type.Boolean.new!(name: "patched"), %Result{name: "patched", type: "boolean"}],
+      [
         Dictionary.Type.Date.new!(name: "date", format: "%Y"),
         %Result{name: "date", type: "date"}
       ],

--- a/apps/service_persist/test/persist/writer_test.exs
+++ b/apps/service_persist/test/persist/writer_test.exs
@@ -54,7 +54,7 @@ defmodule Persist.WriterTest do
       assert "test_catalog" == Keyword.get(init_arg, :catalog)
       assert "test_schema" == Keyword.get(init_arg, :schema)
       assert "table_bobby" == Keyword.get(init_arg, :table)
-      assert [{"name", "varchar"}, {"age", "integer"}] == Keyword.get(init_arg, :table_schema)
+      assert [{"name", "varchar"}, {"age", "bigint"}] == Keyword.get(init_arg, :table_schema)
     end
   end
 

--- a/apps/service_persist/test/persist/writer_test.exs
+++ b/apps/service_persist/test/persist/writer_test.exs
@@ -37,7 +37,9 @@ defmodule Persist.WriterTest do
       dictionary =
         Dictionary.from_list([
           %Dictionary.Type.String{name: "name"},
-          %Dictionary.Type.Integer{name: "age"}
+          %Dictionary.Type.Integer{name: "age"},
+          %Dictionary.Type.Float{name: "score"},
+          %Dictionary.Type.Boolean{name: "applied"}
         ])
 
       Writer.PrestoMock
@@ -54,7 +56,13 @@ defmodule Persist.WriterTest do
       assert "test_catalog" == Keyword.get(init_arg, :catalog)
       assert "test_schema" == Keyword.get(init_arg, :schema)
       assert "table_bobby" == Keyword.get(init_arg, :table)
-      assert [{"name", "varchar"}, {"age", "bigint"}] == Keyword.get(init_arg, :table_schema)
+
+      assert [
+               {"name", "varchar"},
+               {"age", "bigint"},
+               {"score", "double"},
+               {"applied", "boolean"}
+             ] == Keyword.get(init_arg, :table_schema)
     end
   end
 


### PR DESCRIPTION
Updating presto-compatible types to include bigger values than the presto versions of integer and float.

Adding translator for float and bool types to presto versions.