### PR TITLE
More Kubernetes tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,15 @@ Once Strimzi's CRDs are defined, install Hindsight with:
 ```bash
 helm install [NAME] ./helm [opts]
 ```
+
+### AWS
+
+To deploy to AWS, we suggest you start with:
+
+```bash
+helm upgrade --install [NAME] \
+     --namespace [NAMESPACE] \
+     --set global.objectStore.bucketName=[BUCKET_NAME] \
+     --set global.objectStore.region=[AWS_REGION] \
+     --set presto.minio.enable=false
+```

--- a/apps/service_persist/config/test.exs
+++ b/apps/service_persist/config/test.exs
@@ -10,7 +10,6 @@ config :ex_aws,
 
 config :ex_aws, :s3,
   scheme: "http://",
-  region: "local",
   host: %{
     "local" => "localhost"
   },

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -41,6 +41,8 @@ kafka_endpoints =
   |> Enum.map(fn entry -> String.split(entry, ":") end)
   |> Enum.map(fn [host, port] -> {String.to_atom(host), String.to_integer(port)} end)
 
+bucket_region = System.get_env("BUCKET_REGION", "local")
+
 # SERVICE_RECEIVE
 config :service_receive, Receive.Application,
   kafka_endpoints: kafka_endpoints,
@@ -164,6 +166,11 @@ config :service_broadcast, Broadcast.Stream.Broadway,
   ]
 
 # SERVICE PERSIST
+config :ex_aws,
+  region: bucket_region
+
+config :ex_aws, :s3, region: bucket_region
+
 config :service_persist, Persist.Application,
   kafka_endpoints: kafka_endpoints,
   brook: [

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -3,7 +3,7 @@ name: hindsight
 description: A data ingestion engine
 type: application
 version: 0.1.0
-appVersion: 0.0.1
+appVersion: 0.0.2
 home: https://github.com/inhindsight
 sources:
   - https://github.com/inhindsight/hindsight

--- a/helm/templates/persist/deployment.yaml
+++ b/helm/templates/persist/deployment.yaml
@@ -35,6 +35,8 @@ spec:
           env:
             - name: BUCKET_NAME
               value: {{ .Values.global.objectStore.bucketName }}
+            - name: BUCKET_REGION
+              value: {{ .Values.global.objectStore.region }}
             - name: PRESTO_URL
               value: http://{{ template "presto.fullname" . }}:{{ .Values.presto.service.port }}
             - name: KAFKA_ENDPOINTS

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -53,8 +53,8 @@ image:
 global:
   objectStore:
     bucketName: hindsight-object-storage
-    accessKey: accessKey
-    accessSecret: accessSecret
+    accessKey: false
+    accessSecret: false
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -53,6 +53,7 @@ image:
 global:
   objectStore:
     bucketName: hindsight-object-storage
+    region: us-east-1
     accessKey: false
     accessSecret: false
 


### PR DESCRIPTION
With these changes, we're now writing to S3 correctly out of EKS
- `ex_aws_s3` now uses `BUCKET_REGION` environment variable to get correct access to bucket
- `global.objectStorage.{accessKey, accessSecret}` are disabled by default
- Helm updates, including new Docker image version (`0.0.2`)