### PR TITLE
get_by_type/2 workaround

### DIFF
--- a/apps/definition_dictionary/lib/dictionary/impl.ex
+++ b/apps/definition_dictionary/lib/dictionary/impl.ex
@@ -28,7 +28,12 @@ defmodule Dictionary.Impl do
     end
   end
 
-  @spec get_by_type(t, module) :: list(list(String.t()))
+  @spec get_by_type(t | [Dictionary.Type.Normalizer.t()], module) :: list(list(String.t()))
+  def get_by_type(dictionary, module) when is_list(dictionary) do
+    from_list(dictionary)
+    |> get_by_type(module)
+  end
+
   def get_by_type(%__MODULE__{by_type: by_type, ordered: ordered}, type) do
     local =
       Map.get(by_type, type, [])

--- a/apps/definition_dictionary/lib/dictionary/impl.ex
+++ b/apps/definition_dictionary/lib/dictionary/impl.ex
@@ -1,4 +1,6 @@
 defmodule Dictionary.Impl do
+  require Logger
+
   @behaviour Access
 
   @type t :: %__MODULE__{
@@ -30,6 +32,8 @@ defmodule Dictionary.Impl do
 
   @spec get_by_type(t | [Dictionary.Type.Normalizer.t()], module) :: list(list(String.t()))
   def get_by_type(dictionary, module) when is_list(dictionary) do
+    Logger.warn(fn -> "#{__MODULE__}.get_by_type/2: Received list #{inspect(dictionary)}" end)
+
     from_list(dictionary)
     |> get_by_type(module)
   end

--- a/apps/definition_dictionary/test/dictionary_test.exs
+++ b/apps/definition_dictionary/test/dictionary_test.exs
@@ -18,45 +18,46 @@ defmodule DictionaryTest do
       assert Dictionary.Type.String.new!(name: "name") == Dictionary.get_field(dictionary, "name")
     end
 
-    data_test "get_type returns all fields with that type" do
-      dictionary =
-        Dictionary.from_list([
-          Dictionary.Type.String.new!(name: "name"),
-          Dictionary.Type.Integer.new!(name: "age"),
-          Dictionary.Type.Date.new!(name: "birthdate", format: "%Y-%m-%d"),
-          Dictionary.Type.String.new!(name: "nickname"),
-          Dictionary.Type.Map.new!(
-            name: "spouse",
-            dictionary: [
-              Dictionary.Type.String.new!(name: "name"),
-              Dictionary.Type.Wkt.Point.new!(name: "location")
-            ]
-          ),
-          Dictionary.Type.List.new!(
-            name: "friends",
-            item_type:
-              Dictionary.Type.Map.new!(
-                name: "in_list",
-                dictionary: [
-                  Dictionary.Type.String.new!(name: "name"),
-                  Dictionary.Type.Map.new!(
-                    name: "work",
-                    dictionary: [
-                      Dictionary.Type.Wkt.Point.new!(name: "location")
-                    ]
-                  )
-                ]
-              )
-          ),
-          Dictionary.Type.List.new!(
-            name: "colors",
-            item_type: Dictionary.Type.String.new!(name: "in_list")
-          )
-        ])
+    data_test "get_by_type returns all fields with that type" do
+      dictionary = [
+        Dictionary.Type.String.new!(name: "name"),
+        Dictionary.Type.Integer.new!(name: "age"),
+        Dictionary.Type.Date.new!(name: "birthdate", format: "%Y-%m-%d"),
+        Dictionary.Type.String.new!(name: "nickname"),
+        Dictionary.Type.Map.new!(
+          name: "spouse",
+          dictionary: [
+            Dictionary.Type.String.new!(name: "name"),
+            Dictionary.Type.Wkt.Point.new!(name: "location")
+          ]
+        ),
+        Dictionary.Type.List.new!(
+          name: "friends",
+          item_type:
+            Dictionary.Type.Map.new!(
+              name: "in_list",
+              dictionary: [
+                Dictionary.Type.String.new!(name: "name"),
+                Dictionary.Type.Map.new!(
+                  name: "work",
+                  dictionary: [
+                    Dictionary.Type.Wkt.Point.new!(name: "location")
+                  ]
+                )
+              ]
+            )
+        ),
+        Dictionary.Type.List.new!(
+          name: "colors",
+          item_type: Dictionary.Type.String.new!(name: "in_list")
+        )
+      ]
 
-      result = Dictionary.get_by_type(dictionary, type)
+      result_from_list = Dictionary.get_by_type(dictionary, type)
+      result_from_struct = Dictionary.from_list(dictionary) |> Dictionary.get_by_type(type)
 
-      assert MapSet.new(result) == MapSet.new(expected)
+      assert MapSet.new(result_from_list) == MapSet.new(expected)
+      assert MapSet.new(result_from_struct) == MapSet.new(expected)
 
       where [
         [:type, :expected],


### PR DESCRIPTION
I still don't know why we're receiving a list in any `get_by_type/2` usage, but this should work to handle it. Also logs a warning to help us track it down later.