### PR TITLE
Hopeful fixes for negative lag issue

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -151,6 +151,7 @@ config :service_broadcast, Broadcast.Stream.Broadway,
            group_consumer: [
              config: [
                begin_offset: :earliest,
+               offset_reset_policy: :reset_to_latest,
                prefetch_count: 0,
                prefetch_bytes: 2_097_152
              ]
@@ -229,6 +230,7 @@ config :service_persist, Persist.Load.Broadway,
            group_consumer: [
              config: [
                begin_offset: :earliest,
+               offset_reset_policy: :reset_to_earliest,
                prefetch_count: 0,
                prefetch_bytes: 2_097_152
              ]

--- a/helm/presets/aws.yaml
+++ b/helm/presets/aws.yaml
@@ -21,7 +21,7 @@ strimzi:
     resources:
       requests:
         cpu: 500m
-        memory: 6Gi
+        memory: 8Gi
       limits:
         cpu: 1000m
         memory: 8Gi
@@ -32,7 +32,7 @@ strimzi:
         memory: 512Mi
       limits:
         cpu: 250m
-        memory: 1Gi
+        memory: 512Mi
 redis:
   enabled: false
   externalAddress: ""

--- a/helm/presets/aws.yaml
+++ b/helm/presets/aws.yaml
@@ -19,6 +19,9 @@ resources:
 strimzi:
   kafka:
     resources:
+      jvm:
+        xms: 4g
+        xmx: 4g
       requests:
         cpu: 500m
         memory: 8Gi

--- a/helm/templates/kafka/kafka.yaml
+++ b/helm/templates/kafka/kafka.yaml
@@ -6,6 +6,11 @@ metadata:
 spec:
   kafka:
     replicas: {{ .Values.strimzi.kafka.replicaCount }}
+    {{- if .Values.strimzi.kafka.resources.jvm }}
+    jvmOptions:
+      "-Xms": {{ .Values.strimzi.kafka.resources.jvm.xms }}
+      "-Xmx": {{ .Values.strimzi.kafka.resources.jvm.xmx }}
+    {{- end }}
     listeners:
       plain: {}
       tls: {}
@@ -27,6 +32,11 @@ spec:
     {{ end }}
   zookeeper:
     replicas: {{ .Values.strimzi.kafka.replicaCount }}
+    {{- if .Values.strimzi.zookeeper.resources.jvm }}
+    jvmOptions:
+      "-Xms": {{ .Values.strimzi.zookeeper.resources.jvm.xms }}
+      "-Xmx": {{ .Values.strimzi.zookeeper.resources.jvm.xmx }}
+    {{- end }}
     storage:
       {{ if .Values.strimzi.kafka.storage.enabled }}
       type: persistent-claim


### PR DESCRIPTION
- Set `offset_reset_policy` for broadcast and persist
- Preset AWS Kafka pod memory request to 8g
- Preset AWS Zookeeper pod memory limit to 512m
- Allow `-Xms` and `-Xmx` JVM options to be set
- Preset AWS Kafka JVM options to 4g