### PR TITLE
Solidify tool versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,2 @@
-erlang 22.2.4
-erlang 22.2.1
 elixir 1.9.4-otp-22
-elixir 1.9.4
-helm 3.1.1
-helm 3.0.3
+helm 3.1.2


### PR DESCRIPTION
Recent `.tool-versions` changes broke my machine. Turns out that I didn't have the correct Erlang/Elixir versions installed, even though my versions of Erlang/Elixir were in `.tool-versions`.

So this PR makes changes that should be considered the official stance of hindsight:

- Remove Erlang versioning. I don't care what version of Erlang `22.x.x` you're running, and neither does hindsight.
- We do care that you're running Elixir `1.9.x`, because we're reliant on 1.9's release and config changes. Choosing a version that will use a `v22` version of OTP. This makes it so you must use a `v22` Erlang, but again, I don't care what minor/patch versions you're using.
- Upgrade Helm to `v3.1.2`. I'm just choosing the latest release version. It's what we'll be sticking with for awhile.

CHANGES TO THIS FILE MOVING FORWARD WILL BE ASKED TO BE REMOVED UNLESS THERE'S AN EXPLICIT DECISION TO CHANGE A VERSION. Otherwise, I'm going to assume it's a mistake of local configuration and it won't be merged.