### PR TITLE
adding prometheus operator chart

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -9,9 +9,12 @@ sources:
   - https://github.com/inhindsight/hindsight
 dependencies:
   - name: redis
-    version: 10.5.3
+    version: 10.5.7
     repository:  https://kubernetes-charts.storage.googleapis.com
     condition: redis.enabled
   - name: nginx-ingress
-    version: 1.33.4
+    version: 1.34.2
+    repository: https://kubernetes-charts.storage.googleapis.com
+  - name: prometheus-operator
+    version: 8.12.3
     repository: https://kubernetes-charts.storage.googleapis.com

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -18,3 +18,4 @@ dependencies:
   - name: prometheus-operator
     version: 8.12.3
     repository: https://kubernetes-charts.storage.googleapis.com
+    condition: prometheus-operator.enabled

--- a/helm/charts/presto/templates/minio/ingress.yaml
+++ b/helm/charts/presto/templates/minio/ingress.yaml
@@ -5,10 +5,14 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
+{{- if or .Values.minio.ingress.annotations .Values.global.ingress.annotations }}
   annotations:
-{{ toYaml .Values.global.ingress.annotations | trim | indent 4 }}
 {{- if .Values.minio.ingress.annotations }}
 {{ toYaml .Values.minio.ingress.annotations | trim | indent 4 }}
+{{- end }}
+{{- if .Values.global.ingress.annotations }}
+{{ toYaml .Values.global.ingress.annotations | trim | indent 4 }}
+{{- end }}
 {{- end }}
   name: {{ template "presto.minio.fullname" . }}
   labels:

--- a/helm/charts/presto/templates/presto/ingress.yaml
+++ b/helm/charts/presto/templates/presto/ingress.yaml
@@ -4,10 +4,14 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
+{{- if or .Values.presto.ingress.annotations .Values.global.ingress.annotations }}
   annotations:
-{{ toYaml .Values.global.ingress.annotations | trim | indent 4 }}
 {{- if .Values.presto.ingress.annotations }}
 {{ toYaml .Values.presto.ingress.annotations | trim | indent 4 }}
+{{- end }}
+{{- if .Values.global.ingress.annotations }}
+{{ toYaml .Values.global.ingress.annotations | trim | indent 4 }}
+{{- end }}
 {{- end }}
   name: {{ template "presto.fullname" . }}
   labels:

--- a/helm/presets/aws.yaml
+++ b/helm/presets/aws.yaml
@@ -45,6 +45,18 @@ nginx-ingress:
       annotations:
         service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
       type: LoadBalancer
+prometheus-operator:
+  prometheus:
+    prometheusSpec:
+      storageSpec:
+        volumeClaimTemplate:
+          spec:
+            storageClassName: gp2
+            accessModes: ["ReadWriteOnce"]
+            resources:
+              requests:
+                storage: 100Gi
+          selector: {}
 presto:
   postgres:
     enable: false

--- a/helm/presets/aws.yaml
+++ b/helm/presets/aws.yaml
@@ -46,7 +46,10 @@ nginx-ingress:
         service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
       type: LoadBalancer
 prometheus-operator:
+  enabled: true
   prometheus:
+    ingress:
+      enabled: true
     prometheusSpec:
       storageSpec:
         volumeClaimTemplate:
@@ -57,6 +60,12 @@ prometheus-operator:
               requests:
                 storage: 100Gi
           selector: {}
+  alertmanager:
+    ingress:
+      enabled: true
+  grafana:
+    ingress:
+      enabled: true
 presto:
   postgres:
     enable: false

--- a/helm/presets/local.yaml
+++ b/helm/presets/local.yaml
@@ -10,7 +10,7 @@ acquire:
   service:
     type: ClusterIP
 ingress:
-  host: chart-example.local
+  host: hindsight.local
 strimzi:
   kafka:
     resources:
@@ -35,17 +35,34 @@ nginx-ingress:
   controller:
     service:
       type: LoadBalancer
+prometheus-operator:
+  prometheus:
+    ingress:
+      hosts: [prometheus.hindsight.local]
+    prometheusSpec:
+      retentionSize: 1GiB
+  alertmanager:
+    alertmanagerSpec:
+      retention: 30m
+    ingress:
+      hosts: [alertmanager.hindsight.local]
+  grafana:
+    adminPassword: hindsight
+    ingress:
+      hosts: [grafana.hindsight.local]
 presto:
   presto:
     ingress:
       enable: true
-      hosts:
-        - chart-example.local/ui
+      annotations:
+        nginx.ingress.kubernetes.io/use-regex: "true"
+      hosts: [storage.hindsight.local/ui]
   minio:
     ingress:
       enable: true
-      hosts:
-        - chart-example.local/minio.*
+      annotations:
+        nginx.ingress.kubernetes.io/use-regex: "true"
+      hosts: [storage.hindsight.local/minio.*]
 global:
   objectStore:
     bucketName: hindsight-object-storage

--- a/helm/presets/local.yaml
+++ b/helm/presets/local.yaml
@@ -35,21 +35,6 @@ nginx-ingress:
   controller:
     service:
       type: LoadBalancer
-prometheus-operator:
-  prometheus:
-    ingress:
-      hosts: [prometheus.hindsight.local]
-    prometheusSpec:
-      retentionSize: 1GiB
-  alertmanager:
-    alertmanagerSpec:
-      retention: 30m
-    ingress:
-      hosts: [alertmanager.hindsight.local]
-  grafana:
-    adminPassword: hindsight
-    ingress:
-      hosts: [grafana.hindsight.local]
 presto:
   presto:
     ingress:

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -9,10 +9,14 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "hindsight.labels" . | nindent 4 }}
+{{- if or .Values.ingress.annotations .Values.global.ingress.annotations }}
   annotations:
-{{ toYaml .Values.global.ingress.annotations | trim | indent 4 }}
 {{- if .Values.ingress.annotations }}
 {{ toYaml .Values.ingress.annotations | trim | indent 4 }}
+{{- end }}
+{{- if .Values.global.ingress.annotations }}
+{{ toYaml .Values.global.ingress.annotations | trim | indent 4 }}
+{{- end }}
 {{- end }}
 spec:
 {{- if .Values.ingress.tls }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -36,22 +36,12 @@ nginx-ingress:
     service:
       type: LoadBalancer
 prometheus-operator:
-  enabled: true
+  enabled: false
   prometheusOperator:
     namespaces:
       releaseNamespace: true
       additional:
         - kube-system
-  prometheus:
-    ingress:
-      enabled: true
-  alertmanager:
-    ingress:
-      enabled: true
-  grafana:
-    ingress:
-      enabled: true
-
 image:
   repository: inhindsight/hindsight
   tag: ""

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -36,6 +36,7 @@ nginx-ingress:
     service:
       type: LoadBalancer
 prometheus-operator:
+  enabled: true
   prometheusOperator:
     namespaces:
       releaseNamespace: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -35,6 +35,21 @@ nginx-ingress:
       enabled: true
     service:
       type: LoadBalancer
+prometheus-operator:
+  prometheusOperator:
+    namespaces:
+      releaseNamespace: true
+      additional:
+        - kube-system
+  prometheus:
+    ingress:
+      enabled: true
+  alertmanager:
+    ingress:
+      enabled: true
+  grafana:
+    ingress:
+      enabled: true
 
 image:
   repository: inhindsight/hindsight
@@ -44,9 +59,7 @@ image:
 global:
   objectStore:
     bucketName: ""
-  ingress:
-    annotations:
-      nginx.ingress.kubernetes.io/use-regex: "true"
+  ingress: {}
 
 imagePullSecrets: []
 nameOverride: ""
@@ -61,6 +74,8 @@ podSecurityContext: {}
 securityContext: {}
 
 ingress:
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
   host: ""
   paths:
     - name: acquire


### PR DESCRIPTION
adds the prometheus operator helm chart to the hindsight chart deployment as a required dependency.

the chart dependency _does_ include a toggle but this is intended to allow for using an existing prometheus or other monitoring stack in the environment if you already have one. Since prometheus does not have a cloud-managed offering, the toggle is in the default values.yaml file and it is assumed to be enabled by default.

because none of the monitoring stack components have app root paths and the `nginx rewrite-target` annotation isn't working for these, they all have a separate virtual host annotation that point to the same loadbalancer (the same as the hindsight app itself).