### PR TITLE
Add persistent storage to Kafka

### DIFF
--- a/helm/presets/aws.yaml
+++ b/helm/presets/aws.yaml
@@ -18,6 +18,9 @@ resources:
     memory: 512Mi
 strimzi:
   kafka:
+    storage:
+      enabled: true
+      size: 100Gi
     resources:
       jvm:
         xms: 4g
@@ -29,6 +32,9 @@ strimzi:
         cpu: 1000m
         memory: 8Gi
   zookeeper:
+    storage:
+      enabled: true
+      size: 1Gi
     resources:
       requests:
         cpu: 100m

--- a/helm/presets/local.yaml
+++ b/helm/presets/local.yaml
@@ -16,10 +16,10 @@ strimzi:
     resources:
       requests:
         cpu: 500m
-        memory: 1000M
+        memory: 512Mi
       limits:
         cpu: 500m
-        memory: 1000M
+        memory: 512Mi
   zookeeper:
     resources:
       requests:

--- a/helm/templates/kafka/kafka.yaml
+++ b/helm/templates/kafka/kafka.yaml
@@ -19,16 +19,15 @@ spec:
       transaction.state.log.replication.factor: {{ .Values.strimzi.kafka.replicaCount }}
       transaction.state.log.min.isr: 2
     storage:
+      {{ if .Values.strimzi.kafka.storage.enabled }}
       type: persistent-claim
-      size: 100Gi
+      size: {{ .Values.strimzi.kafka.storage.size }}
       deleteClaim: false
+      {{ else }}
+      type: ephemeral
+      {{ end }}
     resources:
-      requests:
-        cpu: 500m
-        memory: 1000M
-      limits:
-        cpu: 500m
-        memory: 1000M
+{{ toYaml .Values.strimzi.kafka.resources | indent 6 }}
   zookeeper:
     replicas: {{ .Values.strimzi.kafka.replicaCount }}
     {{- if .Values.strimzi.zookeeper.resources.jvm }}
@@ -37,20 +36,15 @@ spec:
       "-Xmx": {{ .Values.strimzi.zookeeper.resources.jvm.xmx }}
     {{- end }}
     storage:
-      {{ if .Values.strimzi.kafka.storage.enabled }}
+      {{ if .Values.strimzi.zookeeper.storage.enabled }}
       type: persistent-claim
-      size: 1Gi
+      size: {{ .Values.strimzi.zookeeper.storage.size }}
       deleteClaim: false
       {{ else }}
       type: ephemeral
       {{ end }}
     resources:
-      requests:
-        cpu: 10m
-        memory: 512Mi
-      limits:
-        cpu: 100m
-        memory: 512Mi
+{{ toYaml .Values.strimzi.zookeeper.resources | indent 6 }}
   entityOperator:
     topicOperator: {}
     userOperator: {}

--- a/helm/templates/kafka/kafka.yaml
+++ b/helm/templates/kafka/kafka.yaml
@@ -19,17 +19,16 @@ spec:
       transaction.state.log.replication.factor: {{ .Values.strimzi.kafka.replicaCount }}
       transaction.state.log.min.isr: 2
     storage:
-      {{ if .Values.strimzi.kafka.storage.enabled }}
       type: persistent-claim
-      size: {{ .Values.kafka.storage.size }}
+      size: 100Gi
       deleteClaim: false
-      {{ else }}
-      type: ephemeral
-      {{ end }}
-    {{ if .Values.strimzi.kafka.storage.enabled }}
     resources:
-      {{ .Values.strimzi.kafka.resources }}
-    {{ end }}
+      requests:
+        cpu: 500m
+        memory: 1000M
+      limits:
+        cpu: 500m
+        memory: 1000M
   zookeeper:
     replicas: {{ .Values.strimzi.kafka.replicaCount }}
     {{- if .Values.strimzi.zookeeper.resources.jvm }}
@@ -42,11 +41,16 @@ spec:
       type: persistent-claim
       size: 1Gi
       deleteClaim: false
-      resources:
-        {{ .Values.strimzi.zookeeper.resources }}
       {{ else }}
       type: ephemeral
       {{ end }}
+    resources:
+      requests:
+        cpu: 10m
+        memory: 512Mi
+      limits:
+        cpu: 100m
+        memory: 512Mi
   entityOperator:
     topicOperator: {}
     userOperator: {}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -23,8 +23,12 @@ strimzi:
   kafka:
     replicaCount: 3
     storage:
-      enabled: true
-      size: 100Gi
+      enabled: false
+      size: ""
+  zookeeper:
+    storage:
+      enabled: false
+      size: ""
 redis:
   usePassword: false
   cluster:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -23,8 +23,8 @@ strimzi:
   kafka:
     replicaCount: 3
     storage:
-      enabled: false
-      size: ""
+      enabled: true
+      size: 100Gi
 redis:
   usePassword: false
   cluster:


### PR DESCRIPTION
This implements https://pillartechnology.atlassian.net/browse/DE-29 by setting up persistent storage for Kafka/Zookeeper when deploying to AWS and ephemeral for local.