### PR TITLE
Add release workflow to actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,18 @@
+name: Release
+on:
+  release:
+    types:
+      - created
+jobs:
+  publish:
+    name: Push release Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Push
+        uses: elgohr/Publish-Docker-Github-Action@2.12
+        with:
+          name: inhindsight/hindsight
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
On a GitHub release, publish Docker image. The release's Git tag is used as the Docker image's tag.