### PR TITLE
adding vernemq chart, regrouping values

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -13,13 +13,16 @@ dependencies:
     repository:  https://kubernetes-charts.storage.googleapis.com
     condition: redis.enabled
   - name: nginx-ingress
-    version: 1.34.2
+    version: 1.36.0
     repository: https://kubernetes-charts.storage.googleapis.com
   - name: prometheus-operator
-    version: 8.12.3
+    version: 8.12.12
     repository: https://kubernetes-charts.storage.googleapis.com
     condition: prometheus-operator.enabled
   - name: cert-manager
-    version: 0.14.1
+    version: 0.14.2
     repository: https://charts.jetstack.io
     condition: cert_manager.enabled
+  - name: vernemq
+    repository: https://vernemq.github.io/docker-vernemq
+    version: 1.6.2

--- a/helm/presets/aws.yaml
+++ b/helm/presets/aws.yaml
@@ -25,7 +25,10 @@ global:
     minio:
       enabled: false
 
-# Strimzi subchart
+# Subchart configuration is namespaced under the subchart's name
+# as a top-level key. For example, the Certificate Manager's subchart is
+# configured under the cert_manager key.
+
 strimzi:
   kafka:
     storage:
@@ -53,12 +56,10 @@ strimzi:
         cpu: 250m
         memory: 512Mi
 
-# Redis subchart
 redis:
   enabled: false
   externalAddress: ""
 
-# Nginx subchart
 nginx-ingress:
   controller:
     service:
@@ -66,7 +67,6 @@ nginx-ingress:
         service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
       type: LoadBalancer
 
-# Prometheus subchart
 prometheus-operator:
   enabled: true
   prometheus:
@@ -89,7 +89,6 @@ prometheus-operator:
     ingress:
       enabled: true
 
-# Presto subchart
 presto:
   postgres:
     enable: false
@@ -99,11 +98,9 @@ presto:
       user: ""
       password: ""
 
-# Cert Manager subchart
 cert_manager:
   enabled: true
 
-# VerneMQ subchart
 vernemq:
   enabled: false
   persistentVolume.size: 25Gi

--- a/helm/presets/aws.yaml
+++ b/helm/presets/aws.yaml
@@ -16,6 +16,16 @@ resources:
   limits:
     cpu: 500m
     memory: 512Mi
+
+global:
+  objectStore:
+    region: "us-east-2"
+    accessKey: ""
+    accessSecret: ""
+    minio:
+      enabled: false
+
+# Strimzi subchart
 strimzi:
   kafka:
     storage:
@@ -42,15 +52,21 @@ strimzi:
       limits:
         cpu: 250m
         memory: 512Mi
+
+# Redis subchart
 redis:
   enabled: false
   externalAddress: ""
+
+# Nginx subchart
 nginx-ingress:
   controller:
     service:
       annotations:
         service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
       type: LoadBalancer
+
+# Prometheus subchart
 prometheus-operator:
   enabled: true
   prometheus:
@@ -72,6 +88,8 @@ prometheus-operator:
   grafana:
     ingress:
       enabled: true
+
+# Presto subchart
 presto:
   postgres:
     enable: false
@@ -81,13 +99,16 @@ presto:
       user: ""
       password: ""
 
+# Cert Manager subchart
 cert_manager:
   enabled: true
 
-global:
-  objectStore:
-    region: "us-east-2"
-    accessKey: ""
-    accessSecret: ""
-    minio:
-      enabled: false
+# VerneMQ subchart
+vernemq:
+  enabled: false
+  persistentVolume.size: 25Gi
+  replicaCount: 3
+  service:
+    type: LoadBalancer
+  serviceMonitor:
+    enabled: true

--- a/helm/presets/local.yaml
+++ b/helm/presets/local.yaml
@@ -71,3 +71,8 @@ vernemq:
   enabled: true
   service:
     type: LoadBalancer
+  additionalEnv:
+    - name: DOCKER_VERNEMQ_ALLOW_ANONYMOUS
+      value: "on"
+    - name: DOCKER_VERNEMQ_USER_HINDSIGHT
+      value: "hindsight"

--- a/helm/presets/local.yaml
+++ b/helm/presets/local.yaml
@@ -23,7 +23,10 @@ global:
       port: 9000
       scheme: "http://"
 
-# Strimzi subchart
+# Subchart configuration is namespaced under the subchart's name
+# as a top-level key. For example, the Certificate Manager's subchart is
+# configured under the cert_manager key.
+
 strimzi:
   kafka:
     resources:
@@ -42,7 +45,6 @@ strimzi:
         cpu: 100m
         memory: 512Mi
 
-# Redis subchart
 redis:
   enabled: true
   externalAddress: ""
@@ -51,7 +53,6 @@ nginx-ingress:
     service:
       type: LoadBalancer
 
-# Presto subchart
 presto:
   presto:
     ingress:
@@ -66,7 +67,6 @@ presto:
         nginx.ingress.kubernetes.io/use-regex: "true"
       hosts: [storage.hindsight.local/minio.*]
 
-# VerneMQ subchart
 vernemq:
   enabled: true
   service:

--- a/helm/presets/local.yaml
+++ b/helm/presets/local.yaml
@@ -12,6 +12,18 @@ acquire:
 ingress:
   host: hindsight.local
   tls: []
+global:
+  objectStore:
+    bucketName: hindsight-object-storage
+    region: local
+    accessKey: hindsightAccessKey
+    accessSecret: hindsightAccessSecret
+    minio:
+      enabled: true
+      port: 9000
+      scheme: "http://"
+
+# Strimzi subchart
 strimzi:
   kafka:
     resources:
@@ -29,6 +41,8 @@ strimzi:
       limits:
         cpu: 100m
         memory: 512Mi
+
+# Redis subchart
 redis:
   enabled: true
   externalAddress: ""
@@ -36,6 +50,8 @@ nginx-ingress:
   controller:
     service:
       type: LoadBalancer
+
+# Presto subchart
 presto:
   presto:
     ingress:
@@ -49,13 +65,9 @@ presto:
       annotations:
         nginx.ingress.kubernetes.io/use-regex: "true"
       hosts: [storage.hindsight.local/minio.*]
-global:
-  objectStore:
-    bucketName: hindsight-object-storage
-    region: local
-    accessKey: hindsightAccessKey
-    accessSecret: hindsightAccessSecret
-    minio:
-      enabled: true
-      port: 9000
-      scheme: "http://"
+
+# VerneMQ subchart
+vernemq:
+  enabled: true
+  service:
+    type: LoadBalancer

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -60,7 +60,10 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
-# Strimzi subchart
+# Subchart configuration is namespaced under the subchart's name
+# as a top-level key. For example, the Certificate Manager's subchart is
+# configured under the cert_manager key.
+
 strimzi:
   enabled: true
   kafka:
@@ -73,13 +76,11 @@ strimzi:
       enabled: false
       size: ""
 
-# Redis subchart
 redis:
   usePassword: false
   cluster:
     enabled: false
 
-# Nginx Ingress subchart
 nginx-ingress:
   controller:
     metrics:
@@ -87,7 +88,6 @@ nginx-ingress:
     service:
       type: LoadBalancer
 
-# Prometheus subchart
 prometheus-operator:
   enabled: false
   prometheusOperator:
@@ -96,11 +96,9 @@ prometheus-operator:
       additional:
         - kube-system
 
-# Cert-Manager subchart
 cert_manager:
   enabled: false
 
-# VerneMQ subchart
 vernemq:
   enabled: false
   image:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -18,34 +18,6 @@ acquire:
   replicaCount: 1
   service:
     port: 80
-strimzi:
-  enabled: true
-  kafka:
-    replicaCount: 3
-    storage:
-      enabled: false
-      size: ""
-  zookeeper:
-    storage:
-      enabled: false
-      size: ""
-redis:
-  usePassword: false
-  cluster:
-    enabled: false
-nginx-ingress:
-  controller:
-    metrics:
-      enabled: true
-    service:
-      type: LoadBalancer
-prometheus-operator:
-  enabled: false
-  prometheusOperator:
-    namespaces:
-      releaseNamespace: true
-      additional:
-        - kube-system
 image:
   repository: inhindsight/hindsight
   tag: ""
@@ -68,9 +40,6 @@ serviceAccount:
 podSecurityContext: {}
 securityContext: {}
 
-cert_manager:
-  enabled: false
-
 ingress:
   annotations:
     nginx.ingress.kubernetes.io/use-regex: "true"
@@ -90,3 +59,50 @@ resources: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+# Strimzi subchart
+strimzi:
+  enabled: true
+  kafka:
+    replicaCount: 3
+    storage:
+      enabled: false
+      size: ""
+  zookeeper:
+    storage:
+      enabled: false
+      size: ""
+
+# Redis subchart
+redis:
+  usePassword: false
+  cluster:
+    enabled: false
+
+# Nginx Ingress subchart
+nginx-ingress:
+  controller:
+    metrics:
+      enabled: true
+    service:
+      type: LoadBalancer
+
+# Prometheus subchart
+prometheus-operator:
+  enabled: false
+  prometheusOperator:
+    namespaces:
+      releaseNamespace: true
+      additional:
+        - kube-system
+
+# Cert-Manager subchart
+cert_manager:
+  enabled: false
+
+# VerneMQ subchart
+vernemq:
+  enabled: false
+  image:
+    repository: jeffgrunewald/vernemq
+    tag: latest

--- a/scripts/install
+++ b/scripts/install
@@ -28,8 +28,7 @@ function check_strimzi {
 
 function deps {
     info "Installing Helm dependencies"
-    helm repo add google https://kubernetes-charts.storage.googleapis.com
-    (cd ./helm; helm dependency build)
+    (cd ./helm; helm dependency update)
 }
 
 function strimzi {
@@ -40,7 +39,7 @@ function strimzi {
         info "Installing Strimzi"
         helm upgrade strimzi-kafka-operator strimzi/strimzi-kafka-operator \
              --install \
-             --version 0.16.2 \
+             --version 0.17.0 \
              --set watchAnyNamespace=true
 
         check_strimzi 300s


### PR DESCRIPTION
Adds VerneMQ cluster
- defaults to single node in local, 3 nodes in aws
- regroups the subchart values to make them easier to sort out from hindsight variables
- cleans up the install script/dependencies
- NOTE leaves Verne turned off in aws for the time being until it's needed/development of consumer progresses further