### PR TITLE
enables mqtt 5 in verne cluster

### DIFF
--- a/helm/presets/aws.yaml
+++ b/helm/presets/aws.yaml
@@ -103,9 +103,15 @@ cert_manager:
 
 vernemq:
   enabled: false
-  persistentVolume.size: 25Gi
+  persistentVolume:
+    size: 25Gi
   replicaCount: 3
   service:
     type: LoadBalancer
   serviceMonitor:
     enabled: true
+  additionalEnv:
+    - name: DOCKER_VERNEMQ_LISTENER__TCP__ALLOWED_PROTOCOL_VERSIONS
+      value: "3,4,5"
+    - name: DOCKER_VERNEMQ_LISTENER__SSL__ALLOWED_PROTOCOL_VERSIONS
+      value: "3,4,5"

--- a/helm/presets/local.yaml
+++ b/helm/presets/local.yaml
@@ -72,6 +72,10 @@ vernemq:
   service:
     type: LoadBalancer
   additionalEnv:
+    - name: DOCKER_VERNEMQ_LISTENER__TCP__ALLOWED_PROTOCOL_VERSIONS
+      value: "3,4,5"
+    - name: DOCKER_VERNEMQ_LISTENER__SSL__ALLOWED_PROTOCOL_VERSIONS
+      value: "3,4,5"
     - name: DOCKER_VERNEMQ_ALLOW_ANONYMOUS
       value: "on"
     - name: DOCKER_VERNEMQ_USER_HINDSIGHT


### PR DESCRIPTION
Verne fully supports MQTT 5 but doesn't enable it by default. Enabling all three major versions:
3=3.1
4=3.1.1
5=5 (surprise surprise)