### PR TITLE
Ability to extend hindsight with custom protocol implementations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,3 +19,4 @@ ENV PORT=80
 EXPOSE ${PORT}
 WORKDIR /opt/app
 COPY --from=build /opt/app/_build/prod/rel/ .
+RUN mkdir plugins

--- a/apps/plugins/.formatter.exs
+++ b/apps/plugins/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/apps/plugins/.gitignore
+++ b/apps/plugins/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+plugins-*.tar
+

--- a/apps/plugins/README.md
+++ b/apps/plugins/README.md
@@ -1,21 +1,44 @@
 # Plugins
 
-**TODO: Add description**
+This app provides a single function meant to find and load custom protocol implementations. The
+function should be used on application startup.
+
+``` elixir
+# application.ex
+def start(_, _) do
+  Plugins.load!()
+  
+  # ...
+end
+```
+
+Plugin files in a top-level `plugins` directory will be compiled and loaded into that application.
+Plugins must end in `.ex`. They can be nested in subdirectories. The glob for finding plugins is
+`plugins/**/*.ex`.
+
+Plugins that don't compile will raise exceptions and blow up the dependent application. This
+is the intended design.
+
+## Docker
+
+The Hindsight [Dockerfile](../../Dockerfile) creates a plugins directory for this purpose.
+Any plugin copied into this directory will be made available to all standard Hindsight services.
+
+You will have to build your own image from the official Hindsight image.
+
+```dockerfile
+FROM inhindsight/hindsight:latest
+COPY my_plugins/ plugins/
+```
+
+You will also need to specify your `image.repository` and `image.tag` when using `helm`.
 
 ## Installation
-
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `plugins` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
   [
-    {:plugins, "~> 0.1.0"}
+    {:plugins, in_umbrella: true}
   ]
 end
 ```
-
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/plugins](https://hexdocs.pm/plugins).
-

--- a/apps/plugins/README.md
+++ b/apps/plugins/README.md
@@ -1,0 +1,21 @@
+# Plugins
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+by adding `plugins` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:plugins, "~> 0.1.0"}
+  ]
+end
+```
+
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
+and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+be found at [https://hexdocs.pm/plugins](https://hexdocs.pm/plugins).
+

--- a/apps/plugins/lib/plugins.ex
+++ b/apps/plugins/lib/plugins.ex
@@ -1,0 +1,49 @@
+defmodule Plugins do
+  @moduledoc """
+  Utility module allowing Hindsight services to compile, load, and use
+  custom protocol implementations. Custom impls must be placed in a `plugins/`
+  directory at the running service's top level.
+
+  The `plugins/` directory may contain any level of nested directories. All
+  plugin files must end in `.ex` to be compiled.
+  """
+  use Properties, otp_app: :plugins
+  require Logger
+
+  defmodule PluginError do
+    defexception [:message]
+  end
+
+  getter(:source_dir, default: "plugins")
+
+  @spec load!() :: :ok
+  def load! do
+    load_plugins()
+    |> case do
+      {:ok, plugins} ->
+        count = Enum.reject(plugins, &is_nil/1) |> Enum.count()
+        Logger.info(fn -> "#{__MODULE__}: Loaded #{count} plugin files" end)
+        :ok
+
+      {:error, reason} ->
+        raise PluginError.exception(message: inspect(reason))
+    end
+  end
+
+  defp load_plugins do
+    "#{source_dir()}/**/*.ex"
+    |> Path.wildcard()
+    |> Enum.map(&Path.expand/1)
+    |> Ok.transform(&require_file/1)
+  end
+
+  defp require_file(path) do
+    success = Code.require_file(path)
+    Logger.debug(fn -> "#{__MODULE__}: Loaded #{path} plugin file" end)
+    Ok.ok(success)
+  catch
+    _, reason ->
+      Logger.error(fn -> "#{__MODULE__}: Failed to load plugin file #{path}" end)
+      Ok.error(reason)
+  end
+end

--- a/apps/plugins/mix.exs
+++ b/apps/plugins/mix.exs
@@ -1,0 +1,32 @@
+defmodule Plugins.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :plugins,
+      version: "0.1.0",
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.9",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      {:properties, in_umbrella: true},
+      {:testing, in_umbrella: true, only: [:test]}
+    ]
+  end
+end

--- a/apps/plugins/test/plugins/bad/broken_plugin.ex
+++ b/apps/plugins/test/plugins/bad/broken_plugin.ex
@@ -1,0 +1,2 @@
+defmodule do
+end

--- a/apps/plugins/test/plugins/bad/unloaded_plugin.ex
+++ b/apps/plugins/test/plugins/bad/unloaded_plugin.ex
@@ -1,0 +1,5 @@
+defmodule UnloadedPlugin do
+  def foo do
+    :bar
+  end
+end

--- a/apps/plugins/test/plugins/good/plugin_file_one.ex
+++ b/apps/plugins/test/plugins/good/plugin_file_one.ex
@@ -1,0 +1,3 @@
+defmodule FirstPlugin do
+  def foo, do: :foo
+end

--- a/apps/plugins/test/plugins/good/plugin_file_two.ex
+++ b/apps/plugins/test/plugins/good/plugin_file_two.ex
@@ -1,0 +1,7 @@
+defmodule SecondPlugin do
+  def bar, do: :bar
+end
+
+defmodule ThirdPlugin do
+  def baz, do: :baz
+end

--- a/apps/plugins/test/plugins_test.exs
+++ b/apps/plugins/test/plugins_test.exs
@@ -1,0 +1,50 @@
+defmodule PluginsTest do
+  use ExUnit.Case
+  import ExUnit.CaptureLog
+  require Temp.Env
+
+  describe "with valid plugins" do
+    Temp.Env.modify([%{app: :plugins, key: Plugins, set: [source_dir: "test/plugins/good"]}])
+
+    test "load!/0 compiles and loads plugin modules" do
+      log = capture_log([level: :info], fn -> Plugins.load!() end)
+
+      assert Code.ensure_loaded?(FirstPlugin)
+      assert Code.ensure_loaded?(SecondPlugin)
+      assert Code.ensure_loaded?(ThirdPlugin)
+
+      assert log =~ "Loaded 2 plugin files"
+    end
+  end
+
+  describe "with non-existent source directory" do
+    Temp.Env.modify([%{app: :plugins, key: Plugins, set: [source_dir: "test/plugins/noop"]}])
+
+    test "load!/0 compiles and loads no plugins" do
+      log = capture_log([level: :info], fn -> Plugins.load!() end)
+      assert log =~ "Loaded 0 plugin files"
+    end
+  end
+
+  describe "with empty source directory" do
+    Temp.Env.modify([%{app: :plugins, key: Plugins, set: [source_dir: "test/plugins/empty"]}])
+
+    test "load!/0 compiles and loads no plugins" do
+      log = capture_log([level: :info], fn -> Plugins.load!() end)
+      assert log =~ "Loaded 0 plugin files"
+    end
+  end
+
+  describe "with invalid plugins" do
+    Temp.Env.modify([%{app: :plugins, key: Plugins, set: [source_dir: "test/plugins/bad"]}])
+
+    test "load!/0 raises an exception" do
+      log =
+        capture_log([level: :error], fn ->
+          assert_raise Plugins.PluginError, fn -> Plugins.load!() end
+        end)
+
+      assert log =~ "Failed to load plugin file"
+    end
+  end
+end

--- a/apps/plugins/test/test_helper.exs
+++ b/apps/plugins/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/apps/service_acquire/lib/acquire/application.ex
+++ b/apps/service_acquire/lib/acquire/application.ex
@@ -9,6 +9,8 @@ defmodule Acquire.Application do
   def instance(), do: :acquire_instance
 
   def start(_type, _args) do
+    Plugins.load!()
+
     children = [
       Acquire.MetricsReporter,
       start_brook(),

--- a/apps/service_acquire/mix.exs
+++ b/apps/service_acquire/mix.exs
@@ -45,6 +45,7 @@ defmodule Acquire.MixProject do
       {:phoenix, "~> 1.4.11"},
       {:phoenix_pubsub, "~> 1.1"},
       {:plug_cowboy, "~> 2.0"},
+      {:plugins, in_umbrella: true},
       {:prestige, "~> 1.0"},
       {:properties, in_umbrella: true},
       {:transformer, in_umbrella: true},

--- a/apps/service_broadcast/lib/broadcast/application.ex
+++ b/apps/service_broadcast/lib/broadcast/application.ex
@@ -7,6 +7,8 @@ defmodule Broadcast.Application do
   def instance(), do: :broadcast_instance
 
   def start(_type, _args) do
+    Plugins.load!()
+
     children =
       [
         Broadcast.Cache.Registry,

--- a/apps/service_broadcast/mix.exs
+++ b/apps/service_broadcast/mix.exs
@@ -45,6 +45,7 @@ defmodule Broadcast.MixProject do
       {:phoenix, "~> 1.4.11"},
       {:phoenix_pubsub, "~> 1.1"},
       {:plug_cowboy, "~> 2.0"},
+      {:plugins, in_umbrella: true},
       {:properties, in_umbrella: true},
       {:protocol_source, in_umbrella: true},
       {:transformer, in_umbrella: true},

--- a/apps/service_gather/lib/gather/application.ex
+++ b/apps/service_gather/lib/gather/application.ex
@@ -7,6 +7,8 @@ defmodule Gather.Application do
   def instance(), do: :gather_instance
 
   def start(_type, _args) do
+    Plugins.load!()
+
     children =
       [
         Gather.Extraction.Registry,

--- a/apps/service_gather/mix.exs
+++ b/apps/service_gather/mix.exs
@@ -37,6 +37,7 @@ defmodule Gather.MixProject do
       {:initializer, in_umbrella: true},
       {:management, in_umbrella: true},
       {:metrics_reporter, in_umbrella: true},
+      {:plugins, in_umbrella: true},
       {:properties, in_umbrella: true},
       {:retry, "~> 0.13.0"},
       {:transformer, in_umbrella: true},

--- a/apps/service_orchestrate/lib/orchestrate/application.ex
+++ b/apps/service_orchestrate/lib/orchestrate/application.ex
@@ -7,6 +7,8 @@ defmodule Orchestrate.Application do
   def instance(), do: :orchestrate_instance
 
   def start(_type, _args) do
+    Plugins.load!()
+
     children =
       [
         Orchestrate.MetricsReporter,

--- a/apps/service_orchestrate/mix.exs
+++ b/apps/service_orchestrate/mix.exs
@@ -33,6 +33,7 @@ defmodule Orchestrate.MixProject do
       {:extractor, in_umbrella: true},
       {:management, in_umbrella: true},
       {:metrics_reporter, in_umbrella: true},
+      {:plugins, in_umbrella: true},
       {:properties, in_umbrella: true},
       {:quantum, "~> 2.3"},
       {:timex, "~> 3.0"},

--- a/apps/service_persist/lib/persist/application.ex
+++ b/apps/service_persist/lib/persist/application.ex
@@ -7,6 +7,8 @@ defmodule Persist.Application do
   def instance(), do: :persist_instance
 
   def start(_type, _args) do
+    Plugins.load!()
+
     children =
       [
         Persist.Load.Registry,

--- a/apps/service_persist/mix.exs
+++ b/apps/service_persist/mix.exs
@@ -40,6 +40,7 @@ defmodule Persist.MixProject do
       {:jason, "~> 1.1"},
       {:management, in_umbrella: true},
       {:metrics_reporter, in_umbrella: true},
+      {:plugins, in_umbrella: true},
       {:poison, "~> 4.0"},
       {:properties, in_umbrella: true},
       {:protocol_source, in_umbrella: true},

--- a/apps/service_profile/lib/profile/application.ex
+++ b/apps/service_profile/lib/profile/application.ex
@@ -7,6 +7,8 @@ defmodule Profile.Application do
   def instance(), do: :profile_instance
 
   def start(_type, _args) do
+    Plugins.load!()
+
     children =
       [
         Profile.Feed.Registry,

--- a/apps/service_profile/mix.exs
+++ b/apps/service_profile/mix.exs
@@ -36,6 +36,7 @@ defmodule Profile.MixProject do
       {:initializer, in_umbrella: true},
       {:management, in_umbrella: true},
       {:metrics_reporter, in_umbrella: true},
+      {:plugins, in_umbrella: true},
       {:properties, in_umbrella: true},
       {:protocol_source, in_umbrella: true},
       {:checkov, "~> 1.0", only: [:dev, :test]},

--- a/apps/service_receive/lib/receive/application.ex
+++ b/apps/service_receive/lib/receive/application.ex
@@ -7,6 +7,8 @@ defmodule Receive.Application do
   def instance(), do: :receive_instance
 
   def start(_type, _args) do
+    Plugins.load!()
+
     children =
       [
         Receive.Accept.Registry,

--- a/apps/service_receive/mix.exs
+++ b/apps/service_receive/mix.exs
@@ -37,6 +37,7 @@ defmodule Receive.MixProject do
       {:initializer, in_umbrella: true},
       {:management, in_umbrella: true},
       {:metrics_reporter, in_umbrella: true},
+      {:plugins, in_umbrella: true},
       {:properties, in_umbrella: true},
       {:transformer, in_umbrella: true},
       {:credo, "~> 1.3", only: [:dev]},


### PR DESCRIPTION
If I want to add a custom, very specific-to-me `Source` implementation to Hindsight, I can bake it into an extending Docker image and Hindsight will pull it into the system.

```elixir
# my_plugins/foo.ex
defmodule Foo do
  defstruct [:bar, :baz]

  defimpl Source do
    # ...
  end
end
```
```Dockerfile
FROM inhindsight/hindsight:latest
COPY my_plugins/ plugins/
```
```
$ docker build -t myhindsight:extended .
```
All Hindsight services started in the `myhindsight/hindsight` image will compile and load plugins on startup. And so, the `Foo` destination is available for use throughout the system. This should work for any/all protocol implementations.

If a plugin file can't be compiled, applications will blow up immediately so users can't continue on the assumption that everything is OK. If no plugins exist or the directory is missing (local dev), Hindsight considers everything fine.

Some things to consider:
1. I'm not testing this through the Docker layer beyond manually.
2. Developing a custom impl will be a PITA since that code base will have no reference to our protocols without recreating them.
3. Deploying via Helm will require `image.repository` and `image.tag` to be set to the extended image values.