### PR TITLE
Dictionary.Type.Timestamp default format value

### DIFF
--- a/apps/definition_dictionary/lib/dictionary/type/timestamp.ex
+++ b/apps/definition_dictionary/lib/dictionary/type/timestamp.ex
@@ -31,7 +31,7 @@ defmodule Dictionary.Type.Timestamp do
   defstruct version: 1,
             name: nil,
             description: "",
-            format: nil,
+            format: "%FT%T.%fZ",
             timezone: "Etc/UTC"
 
   defimpl Dictionary.Type.Normalizer, for: __MODULE__ do

--- a/apps/definition_dictionary/test/dictionary/type/timestamp_test.exs
+++ b/apps/definition_dictionary/test/dictionary/type/timestamp_test.exs
@@ -21,6 +21,13 @@ defmodule Dictionary.Type.TimestampTest do
              |> Jason.decode!()
   end
 
+  test "default format parses ISO8601 DateTime string" do
+    now = DateTime.utc_now() |> DateTime.to_iso8601()
+    timestamp = Dictionary.Type.Timestamp.new!(name: "foo")
+
+    assert {:ok, _} = Timex.parse(now, timestamp.format, Timex.Parse.DateTime.Tokenizers.Strftime)
+  end
+
   test "can be decoded back into struct" do
     string =
       Dictionary.Type.Timestamp.new!(name: "name", description: "description", format: "%Y")


### PR DESCRIPTION
I'm not sure why this isn't set, but now it parses `DateTime.utc_now() |> DateTime.to_iso8601()` string by default.